### PR TITLE
industry/subsector fixes to DeepEl

### DIFF
--- a/core/loop.gms
+++ b/core/loop.gms
@@ -164,13 +164,13 @@ if (o_modelstat le 2,
   !! commands
   if (c_keep_iteration_gdxes eq 1,
     put_utility logfile, "shell" / 
-    "cp fulldata.gdx fulldata_" iteration.val:0:0 ".gdx";
+      "cp fulldata.gdx fulldata_" iteration.val:0:0 ".gdx";
   );
 else
   execute_unload 'non_optimal';
   if (c_keep_iteration_gdxes eq 1,
     put_utility logfile, "shell" / 
-    "cp non_optimal.gdx non_optimal_" iteration.val:0:0 ".gdx";
+      "cp non_optimal.gdx non_optimal_" iteration.val:0:0 ".gdx";
   );
 );
 logfile.nr = 2;

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -140,10 +140,6 @@ p37_clinker_cement_ratio(t,regi)
 *** costs have to be calculated.
 pm_CementDemandReductionCost(ttot,regi) = 0;
 
-if (cm_emiscen ne 1,
-  Execute_Loadpoint "input_ref.gdx" p37_cesIO_base = vm_cesIO.l;
-);
-
 *** FIXME calibration debug
 Parameter
   p37_arcane_FE_limits(all_in,all_in)   "minimum ratio of feelhth/feelwlth and feh2/fega (may be needed for calibration)"

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -18,7 +18,6 @@ Parameters
   o37_cementProcessEmissions(ttot,all_regi,all_enty)     "cement process emissions [GtC/a]"
 
   p37_clinker_cement_ratio(ttot,all_regi)   "clinker content per unit cement used"
-  p37_cesIO_base(ttot,all_regi,all_in)      "baseline scenario pf quantities"
 
   pm_ue_eff_target(all_in)   "energy efficiency target trajectories [% p.a.]"
 ;
@@ -38,8 +37,6 @@ Equations
   q37_IndCCS(ttot,all_regi,emiInd37)                      "limit industry emissions abatement"
   q37_cementCCS(ttot,all_regi)                            "link cement fuel and process abatement"
   q37_IndCCSCost                                          "Calculate industry CCS costs"
-  q37_limit_specific_total_energy(ttot,all_regi,all_in)   "limit specific energy use to baseline level"
-  q37_arcane_FE_limits(ttot,all_regi,all_in,all_in)       "minimum ratio of feelhth/feelwlth and feh2/fega (may be needed for calibration)"
 ;
 
 *** EOF ./modules/37_industry/subsectors/declarations.gms

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -28,7 +28,7 @@ q37_limit_secondary_steel_share(ttot,regi)$( ttot.val ge cm_startyear ) ..
 q37_macBaseInd(ttot,regi,entyFE,secInd37)$( ttot.val ge cm_startyear ) .. 
   vm_macBaseInd(ttot,regi,entyFE,secInd37)
   =e=
-    sum(fe2ppfen(entyFE,ppfen_industry_dyn37(in)),
+    sum((secInd37_2_pf(secInd37,ppfen_industry_dyn37(in)),fe2ppfen(entyFE,in)),
       vm_cesIO(ttot,regi,in)
     * p37_fctEmi(entyFE)
     )

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -99,27 +99,5 @@ q37_IndCCSCost(ttot,regi,emiInd37)$( ttot.val ge cm_startyear ) ..
     )
 ;
 
-*' FIXME testing
-*' Limit specific total energy use to that of the baseline run
-q37_limit_specific_total_energy(ttot,regi,in_industry_dyn37(out))$(
-                                                  ttot.val ge cm_startyear ) .. 
-    sum(ces_eff_target_dyn37(out,in), vm_cesIO(ttot,regi,in)) 
-  * p37_cesIO_base(ttot,regi,out)
-  * (cm_emiscen ne 1)  !! not active in BAU run
-  =l=
-    sum(ces_eff_target_dyn37(out,in), p37_cesIO_base(ttot,regi,in))
-  * vm_cesIO(ttot,regi,out)
-;
-*' end FIXME testing
-
-*** FIXME calibration debug
-q37_arcane_FE_limits(ttot,regi,in,in2)$( p37_arcane_FE_limits(in,in2) ) ..
-  vm_cesIO(ttot,regi,in)
-  =g=
-    vm_cesIO(ttot,regi,in2)
-  * p37_arcane_FE_limits(in,in2)
-;
-*** end FIXME calibration debug
-
 *** EOF ./modules/37_industry/subsectors/equations.gms
 


### PR DESCRIPTION
- fix calculation of Industry CCS baseline emissions
  - vm_macBaseInd was calculated across all subsectors, not
    subsector-specific, as was intended
  - this lead to energy use in one subsector causing abatable emissions in
    all subsectors, depressing FE prices (on the CES function) and
    increasing FE use

- fix q37_limit_specific_total_energy 
  - remove obsolete equations used for development and testing