### PR TITLE
fix #286

### DIFF
--- a/modules/35_transport/edge_esm/declarations.gms
+++ b/modules/35_transport/edge_esm/declarations.gms
@@ -6,7 +6,8 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/35_transport/edge_esm/declarations.gms
 Parameters
-pm_bunker_share_in_nonldv_fe(tall,all_regi)   "Share of bunkers in non-LDV transport - fedie"
+  pm_bunker_share_in_nonldv_fe(tall,all_regi)   "Share of bunkers in non-LDV transport - fedie"
+  p35_fe2es_aux(tall,all_regi,all_GDPscen,EDGE_scenario_all,all_teEs) "Aggregate energy efficiency of transport fuel technologies [trn pkm/Twa or trn tkm/Twa]"
 ;
 
 *** EOF ./modules/35_transport/edge_esm/declarations.gms

--- a/modules/35_transport/edge_esm/presolve.gms
+++ b/modules/35_transport/edge_esm/presolve.gms
@@ -15,8 +15,9 @@ if( (ord(iteration) le 25 and ord(iteration) ge 14 and (mod(ord(iteration), 3) e
     Execute_Loadpoint 'p35_esCapCost' p35_esCapCost;
     pm_esCapCost(t,regi,teEs_dyn35)$(t.val > 2010) = p35_esCapCost(t,regi,"%cm_GDPscen%","%cm_EDGEtr_scen%",teEs_dyn35);
 
-    Execute_Loadpoint 'p35_fe2es' p35_fe2es;
-    pm_fe2es(t,regi,teEs_dyn35)$(t.val > 2010) = p35_fe2es(t,regi,"%cm_GDPscen%","%cm_EDGEtr_scen%",teEs_dyn35);
+    Execute_Loadpoint "p35_fe2es", p35_fe2es_aux = p35_fe2es;
+    pm_fe2es(t,regi,teEs_dyn35)$( t.val > 2010 ) 
+    = p35_fe2es_aux(t,regi,"%cm_GDPscen%","%cm_EDGEtr_scen%",teEs_dyn35);
 
     Execute_Loadpoint 'p35_shFeCes' p35_shFeCes;
     pm_shFeCes(t,regi,entyFe,ppfen_dyn35,teEs_dyn35)$(p35_shFeCes(t,regi,"%cm_GDPscen%","%cm_EDGEtr_scen%",entyFe,ppfen_dyn35,teEs_dyn35) AND t.val > 2010) = p35_shFeCes(t,regi,"%cm_GDPscen%","%cm_EDGEtr_scen%",entyFe,ppfen_dyn35,teEs_dyn35);


### PR DESCRIPTION
- EDGE_transport.R overwrites p35_fe2es to update pm_fe2es data after
  2010
- changed values of p35_fe2es are passed on to subsequent runs through
  the gdx
- there they alter the results of initialcap2, potentially leading to
  infeasibilities

- loading values into an auxilliary parameter will prevent this from
  happening