### PR TITLE
fix f307c56 set resLim to 3e6

### DIFF
--- a/core/loop.gms
+++ b/core/loop.gms
@@ -15,7 +15,8 @@ hybrid.optfile   = 1;
 hybrid.holdfixed = 1;
 hybrid.scaleopt  = 1;
 option savepoint = 0;
-option solprint  = off ;
+option resLim    = 3e6;
+option solprint  = off;
 o_modelstat      = 100;
 
 $ifthen.calibrate "%CES_parameters%" == "calibrate"   !! CES_parameters


### PR DESCRIPTION
- contrary to the GAMS documentation
  https://www.gams.com/32/docs/UG_GamsCall.html#GAMSAOreslim
  the resLim default is not 1e10 but 1e3 seconds (16 minutes), which is
  way too little for Remind

- setting resLim to 3e6 allows even for runs on the long QoS (30 days)

- see #265